### PR TITLE
use ERC20 mocks instead forking sepolia

### DIFF
--- a/packages/snfoundry/contracts/src/lib.cairo
+++ b/packages/snfoundry/contracts/src/lib.cairo
@@ -13,5 +13,8 @@ mod interfaces {
 #[cfg(test)]
 mod test {
     mod TestContract;
+    mod mock {
+        mod ERC20;
+    }
 }
 

--- a/packages/snfoundry/contracts/src/test/TestContract.cairo
+++ b/packages/snfoundry/contracts/src/test/TestContract.cairo
@@ -1,7 +1,7 @@
 use contracts::IMarquisCore::{IMarquisCoreDispatcher, IMarquisCoreDispatcherTrait, SupportedToken};
-use contracts::interfaces::ILudo::{ILudoDispatcher, ILudoDispatcherTrait, LudoMove, LudoSessionStatus};
+use contracts::interfaces::ILudo::{ILudoDispatcher, ILudoDispatcherTrait, LudoMove, SessionUserStatus};
 use contracts::interfaces::IMarquisGame::{
-    IMarquisGameDispatcher, IMarquisGameDispatcherTrait, SessionData, VerifiableRandomNumber,
+    IMarquisGameDispatcher, IMarquisGameDispatcherTrait, VerifiableRandomNumber,
 };
 use core::num::traits::Zero;
 use openzeppelin_token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -172,12 +172,40 @@ fn setup_game_4_players(
     (context, players_balance_init)
 }
 
-fn player_move(context: GameContext, ludo_move: @LudoMove, player: ContractAddress, ver_rand_num_array: Array<VerifiableRandomNumber>) -> (SessionData, LudoSessionStatus) {
+fn player_move(context: GameContext, ludo_move: @LudoMove, player: ContractAddress, ver_rand_num_array: Array<VerifiableRandomNumber>) -> (SessionUserStatus, SessionUserStatus, SessionUserStatus, SessionUserStatus) {
 
     cheat_caller_address(context.ludo_contract, player, CheatSpan::TargetCalls(1));
     println!("-- Playing move for player {:?}", player);
     context.ludo_dispatcher.play(context.session_id, ludo_move.clone(), ver_rand_num_array);
-    context.ludo_dispatcher.get_session_status(context.session_id)
+    let (session_data, ludo_session_status) = context.ludo_dispatcher.get_session_status(context.session_id);
+
+    //println!("{:?}", session_data);
+    //println!("{:?}", ludo_session_status);
+    ludo_session_status.users
+}
+
+fn assert_position_0_eq(user:@SessionUserStatus, expected_pos: u256) {
+    let (pos_0, _, _, _) = *user.player_tokens_position;
+    println!("-- User {:?} pin 0 pos: {:?}", user.player_id, pos_0);
+    assert_eq!(pos_0, expected_pos);
+}
+
+fn assert_position_1_eq(user:@SessionUserStatus, expected_pos: u256) {
+    let (_, pos_1, _, _) = *user.player_tokens_position;
+    println!("-- User {:?} pin 1 pos: {:?}", user.player_id, pos_1);
+    assert_eq!(pos_1, expected_pos);
+}
+
+fn assert_position_2_eq(user:@SessionUserStatus, expected_pos: u256) {
+    let (_, _, pos_2, _) = *user.player_tokens_position;
+    println!("-- User {:?} pin 2 pos: {:?}", user.player_id, pos_2);
+    assert_eq!(pos_2, expected_pos);
+}
+
+fn assert_position_3_eq(user:@SessionUserStatus, expected_pos: u256) {
+    let (_, _, _, pos_3) = *user.player_tokens_position;
+    println!("-- User {:?} pin 3 pos: {:?}", user.player_id, pos_3);
+    assert_eq!(pos_3, expected_pos);
 }
 
 // MARQUIS CONTRACT TESTS
@@ -627,12 +655,9 @@ fn test_get_6_and_play() {
     let ver_rand_num0 = VerifiableRandomNumber { random_number: 6, v: 1, r: 1, s: 1 };
     let ver_rand_num1 = VerifiableRandomNumber { random_number: 2, v: 1, r: 1, s: 1 };
     let ver_rand_num_array = array![ver_rand_num0, ver_rand_num1];
-    let (session_data, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    println!("{:?}", session_data);
-    let (user0, _, _, _) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user0.player_tokens_position;
+    let (user0, _, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let expected_pin_0_pos = 3;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user0, expected_pin_0_pos);
 }
 #[test]
 fn test_player_0_doesnt_get_6_and_player_1_does_get_6() {
@@ -645,25 +670,18 @@ fn test_player_0_doesnt_get_6_and_player_1_does_get_6() {
     let ver_rand_num1 = VerifiableRandomNumber { random_number: 2, v: 1, r: 1, s: 1 };
     let ver_rand_num_array = array![ver_rand_num1];
 
-    let (session_data, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    println!("{:?}", session_data);
-    let (user0, _, _, _) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user0.player_tokens_position;
-    println!("-- User 0 pin 0 pos: {:?}", pin_0_pos);
+    let (user0, _, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let expected_pin_0_pos = 0;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user0, expected_pin_0_pos);
 
     // player 1 turn
     let ver_rand_num0 = VerifiableRandomNumber { random_number: 6, v: 1, r: 1, s: 1 };
     let ver_rand_num1 = VerifiableRandomNumber { random_number: 2, v: 1, r: 1, s: 1 };
     let ver_rand_num_array = array![ver_rand_num0, ver_rand_num1];
     
-    let (session_data, ludo_session_status) = player_move(context, @ludo_move, player_1, ver_rand_num_array);
-    println!("{:?}", session_data);
-    let (_, user1, _, _) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (_, user1, _, _) = player_move(context, @ludo_move, player_1, ver_rand_num_array);
     let expected_pin_0_pos = 14 + 2;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user1, expected_pin_0_pos);
 }
 #[test]
 // Player 0 kills player 1 pin0
@@ -685,58 +703,34 @@ fn test_kill() {
 
     let ludo_move = LudoMove { token_id: 0 };
 
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    //println!("{:?}", session_data);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (user0, _, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let expected_user0_pin_0_pos = 1 + 2;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user0_pin_0_pos, expected_user0_pin_0_pos);
+    assert_position_0_eq(@user0, expected_user0_pin_0_pos);
 
     println!("-- Playing move for player 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
-    //println!("{:?}", session_data);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (_, user1, _, _) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
     let expected_use1_pin_0_pos = 14 + 2;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user1_pin_0_pos, expected_use1_pin_0_pos);
+    assert_position_0_eq(@user1, expected_use1_pin_0_pos);
 
     println!("-- Playing move for player 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
-    //println!("{:?}", session_data);
-    let (_, _, user2, _) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user2.player_tokens_position;
+    let (_, _, user2, _) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
     let expected_pin_0_pos = 27 + 2;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user2, expected_pin_0_pos);
 
     println!("-- Playing move for player 3");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
-    //println!("{:?}", session_data);
-    let (_, _, _, user3) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user3.player_tokens_position;
+    let (_, _, _, user3) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
     let expected_pin_0_pos = 40 + 2;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user3, expected_pin_0_pos);
 
     println!("-- Playing move for player 0 again");
     let ver_rand_num0 = VerifiableRandomNumber { random_number: 6, v: 1, r: 1, s: 1 };
     let ver_rand_num1 = VerifiableRandomNumber { random_number: 6, v: 1, r: 1, s: 1 };
     let ver_rand_num2 = VerifiableRandomNumber { random_number: 1, v: 1, r: 1, s: 1 };
     let ver_rand_num_array = array![ver_rand_num0, ver_rand_num1, ver_rand_num2];
-    let (session_data, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    println!("{:?}", session_data);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (user0, user1, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let new_expected_user0_pin_0_pos = expected_user0_pin_0_pos + 13;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user0_pin_0_pos, new_expected_user0_pin_0_pos);
-    assert_eq!(user1_pin_0_pos, 0);
+    assert_position_0_eq(@user0, new_expected_user0_pin_0_pos);
+    assert_position_0_eq(@user1, 0);
 }
 #[test]
 fn test_user0_pin0_wins() {
@@ -778,55 +772,32 @@ fn test_user0_pin0_wins() {
     let ludo_move = LudoMove { token_id: 0 };
 
     println!("-- Playing move for player 0");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    //println!("{:?}", session_data);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (user0, _, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let expected_user0_pin_0_pos = 1 + 50;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user0_pin_0_pos, expected_user0_pin_0_pos);
+    assert_position_0_eq(@user0, expected_user0_pin_0_pos);
 
     println!("-- Playing move for player 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
-    //println!("{:?}", session_data);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (_, user1, _, _) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
     let expected_use1_pin_0_pos = (14 + 50) % 52;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user1_pin_0_pos, expected_use1_pin_0_pos);
+    assert_position_0_eq(@user1, expected_use1_pin_0_pos);
 
     println!("-- Playing move for player 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
-    //println!("{:?}", session_data);
-    let (_, _, user2, _) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user2.player_tokens_position;
+    let (_, _, user2, _) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
     let expected_pin_0_pos = (27 + 50) % 52;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user2, expected_pin_0_pos);
 
     println!("-- Playing move for player 3");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
-    let (_, _, _, user3) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user3.player_tokens_position;
+    let (_, _, _, user3) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
     let expected_pin_0_pos = (40 + 50) % 52;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user3, expected_pin_0_pos);
 
     println!("-- Playing move for player 0 again");
     let ver_rand_num0 = VerifiableRandomNumber { random_number: 6, v: 1, r: 1, s: 1 };
     let ver_rand_num_array = array![ver_rand_num0];
-    let (session_data, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    println!("{:?}", session_data);
-    println!("{:?}", ludo_session_status);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (user0, _, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let new_expected_user0_pin_0_pos = expected_user0_pin_0_pos + 6;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user0_pin_0_pos, new_expected_user0_pin_0_pos);
+    assert_position_0_eq(@user0, new_expected_user0_pin_0_pos);
+
     let (user0_pin_0_winning, _, _, _) = user0.player_winning_tokens;
     assert!(user0_pin_0_winning);
 }
@@ -852,15 +823,9 @@ fn test_attack_circled() {
     let ludo_move = LudoMove { token_id: 0 };
 
     println!("-- Playing move for player 0");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    //println!("{:?}", session_data);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (user0, _, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let expected_user0_pin_0_pos = 3;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user0_pin_0_pos, expected_user0_pin_0_pos);
+    assert_position_0_eq(@user0, expected_user0_pin_0_pos);
 
     println!("-- Playing move for player 1");
     let ver_rand_num0 = VerifiableRandomNumber { random_number: 6, v: 1, r: 1, s: 1 };
@@ -884,41 +849,26 @@ fn test_attack_circled() {
         ver_rand_num7,
     ];
 
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
-    //println!("{:?}", session_data);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (_, user1, _, _) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
     let (user1_pin_0_circled, _, _, _) = user1.player_tokens_circled;
     let expected_use1_pin_0_pos = (14 + 42) % 52;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user1_pin_0_pos, expected_use1_pin_0_pos);
+    assert_position_0_eq(@user1, expected_use1_pin_0_pos);
     assert!(user1_pin_0_circled);
 
     println!("-- Playing move for player 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
-    //println!("{:?}", session_data);
-    let (_, _, user2, _) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user2.player_tokens_position;
+    let (_, _, user2, _) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
     let expected_pin_0_pos = 27 + 2;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user2, expected_pin_0_pos);
 
     println!("-- Playing move for player 3");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
-    //println!("{:?}", session_data);
-    let (_, _, _, user3) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user3.player_tokens_position;
+    let (_, _, _, user3) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
     let expected_pin_0_pos = 40 + 2;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user3, expected_pin_0_pos);
 
     println!("-- Playing move for player 0 again");
     let ver_rand_num0 = VerifiableRandomNumber { random_number: 1, v: 1, r: 1, s: 1 };
     let ver_rand_num_array = array![ver_rand_num0];
-    let (session_data, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    println!("{:?}", session_data);
-    println!("{:?}", ludo_session_status);
-    let (user0, user1, _, _) = ludo_session_status.users;
+    let (user0, user1, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
     let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
     let (user1_pin_0_circled, _, _, _) = user1.player_tokens_circled;
@@ -972,42 +922,24 @@ fn test_user0_user1_user2_user3_wins() {
     let ludo_move = LudoMove { token_id: 0 };
 
     println!("-- Playing move for player 0");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    //println!("{:?}", session_data);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (user0, _, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let expected_user0_pin_0_pos = 1 + 56;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user0_pin_0_pos, expected_user0_pin_0_pos);
+    assert_position_0_eq(@user0, expected_user0_pin_0_pos);
 
     println!("-- Playing move for player 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
-    //println!("{:?}", session_data);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (_, user1, _, _) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
     let expected_use1_pin_0_pos = (14 + 56) % 52;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user1_pin_0_pos, expected_use1_pin_0_pos);
+    assert_position_0_eq(@user1, expected_use1_pin_0_pos);
 
     println!("-- Playing move for player 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
-    //println!("{:?}", session_data);
-    let (_, _, user2, _) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user2.player_tokens_position;
+    let (_, _, user2, _) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
     let expected_pin_0_pos = (27 + 56) % 52;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user2, expected_pin_0_pos);
 
     println!("-- Playing move for player 3");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
-    println!("{:?}", ludo_session_status);
-    let (user0, user1, user2, user3) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user3.player_tokens_position;
+    let (user0, user1, user2, user3) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
     let expected_pin_0_pos = (40 + 56) % 52;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user3, expected_pin_0_pos);
 
     let (user0_pin_0_winning, _, _, _) = user0.player_winning_tokens;
     let (user1_pin_0_winning, _, _, _) = user1.player_winning_tokens;
@@ -1079,108 +1011,68 @@ fn test_player0_wins() {
     let ludo_move = LudoMove { token_id: 0 };
 
     println!("-- Playing move for player 0");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (user0, _, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let expected_user0_pin_0_pos = 1 + 56;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user0_pin_0_pos, expected_user0_pin_0_pos);
+    assert_position_0_eq(@user0, expected_user0_pin_0_pos);
 
     println!("-- Playing move for player 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (_, user1, _, _) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
     let expected_use1_pin_0_pos = (14 + 56) % 52;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user1_pin_0_pos, expected_use1_pin_0_pos);
+    assert_position_0_eq(@user1, expected_use1_pin_0_pos);
 
     println!("-- Playing move for player 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
-    let (_, _, user2, _) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user2.player_tokens_position;
+    let (_, _, user2, _) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
     let expected_pin_0_pos = (27 + 56) % 52;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user2, expected_pin_0_pos);
 
     println!("-- Playing move for player 3");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
-    let (_, _, _, user3) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user3.player_tokens_position;
+    let (_, _, _, user3) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
     let expected_pin_0_pos = (40 + 56) % 52;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user3, expected_pin_0_pos);
 
     let ludo_move_1 = LudoMove { token_id: 1 };
 
     println!("-- Playing move for player 0 pin 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_1, player_0, var_rand_num_array4);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (_, user0_pin_1_pos, _, _) = user0.player_tokens_position;
-    let (_, user1_pin_1_pos, _, _) = user1.player_tokens_position;
-    println!("-- User 0 pin 1 pos: {:?}", user0_pin_1_pos);
-    println!("-- User 1 pin 1 pos: {:?}", user1_pin_1_pos);
+    let (user0, _, _, _) = player_move(context, @ludo_move_1, player_0, var_rand_num_array4);
     let expected_user0_pin_1_pos = 1 + 56;
-    assert_eq!(user0_pin_1_pos, expected_user0_pin_1_pos);
-    assert_eq!(user1_pin_1_pos, 0);
+    assert_position_1_eq(@user0, expected_user0_pin_1_pos);
 
     println!("-- Playing move for player 1 pin 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_1, player_1, var_rand_num_array5);
-    let (_, user1, _, _) = ludo_session_status.users;
-    let (_, user1_pin_1_pos, _, _) = user1.player_tokens_position;
+    let (_, user1, _, _) = player_move(context, @ludo_move_1, player_1, var_rand_num_array5);
     let expected_user1_pin_1_pos = (14 + 56) % 52;
-    assert_eq!(user1_pin_1_pos, expected_user1_pin_1_pos);
+    assert_position_1_eq(@user1, expected_user1_pin_1_pos);
 
     println!("-- Playing move for player 2 pin 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_1, player_2, var_rand_num_array6);
-    let (_, _, user2, _) = ludo_session_status.users;
-    let (_, user2_pin_1_pos, _, _) = user2.player_tokens_position;
+    let (_, _, user2, _) = player_move(context, @ludo_move_1, player_2, var_rand_num_array6);
     let expected_user2_pin_1_pos = (27 + 56) % 52;
-    assert_eq!(user2_pin_1_pos, expected_user2_pin_1_pos);
+    assert_position_1_eq(@user2, expected_user2_pin_1_pos);
 
     println!("-- Playing move for player 3 pin 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_1, player_3, var_rand_num_array7);
-    let (_, _, _, user3) = ludo_session_status.users;
-    let (_, user3_pin_1_pos, _, _) = user3.player_tokens_position;
+    let (_, _, _, user3) = player_move(context, @ludo_move_1, player_3, var_rand_num_array7);
     let expected_user3_pin_1_pos = (40 + 56) % 52;
-    assert_eq!(user3_pin_1_pos, expected_user3_pin_1_pos);
+    assert_position_1_eq(@user3, expected_user3_pin_1_pos);
 
     let ludo_move_2 = LudoMove { token_id: 2 };
 
     println!("-- Playing move for player 0 pin 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_2, player_0, var_rand_num_array8);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (_, _, user0_pin_2_pos, _) = user0.player_tokens_position;
-    let (_, _, user1_pin_2_pos, _) = user1.player_tokens_position;
-    println!("-- User 0 pin 2 pos: {:?}", user0_pin_2_pos);
-    println!("-- User 1 pin 2 pos: {:?}", user1_pin_2_pos);
+    let (user0, _, _, _) = player_move(context, @ludo_move_2, player_0, var_rand_num_array8);
     let expected_user0_pin_2_pos = 1 + 56;
-    assert_eq!(user0_pin_2_pos, expected_user0_pin_2_pos);
-    assert_eq!(user1_pin_2_pos, 0);
+    assert_position_2_eq(@user0, expected_user0_pin_2_pos);
 
     println!("-- Playing move for player 1 pin 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_2, player_1, var_rand_num_array9);
-    let (_, user1, _, _) = ludo_session_status.users;
-    let (_, _, user1_pin_2_pos, _) = user1.player_tokens_position;
+    let (_, user1, _, _) = player_move(context, @ludo_move_2, player_1, var_rand_num_array9);
     let expected_user1_pin_2_pos = (14 + 56) % 52;
-    assert_eq!(user1_pin_2_pos, expected_user1_pin_2_pos);
+    assert_position_2_eq(@user1, expected_user1_pin_2_pos);
 
     println!("-- Playing move for player 2 pin 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_2, player_2, var_rand_num_array10);
-    let (_, _, user2, _) = ludo_session_status.users;
-    let (_, _, user2_pin_2_pos, _) = user2.player_tokens_position;
+    let (_, _, user2, _) = player_move(context, @ludo_move_2, player_2, var_rand_num_array10);
     let expected_user2_pin_2_pos = (27 + 56) % 52;
-    assert_eq!(user2_pin_2_pos, expected_user2_pin_2_pos);
+    assert_position_2_eq(@user2, expected_user2_pin_2_pos);
 
     println!("-- Playing move for player 3 pin 2");
-    let (session_data, ludo_session_status) = player_move(context, @ludo_move_2, player_3, var_rand_num_array11);
-    println!("{:?}", session_data);
-    println!("{:?}", ludo_session_status);
-    let (_, _, _, user3) = ludo_session_status.users;
-    let (_, _, user3_pin_2_pos, _) = user3.player_tokens_position;
+    let (_, _, _, user3) = player_move(context, @ludo_move_2, player_3, var_rand_num_array11);
     let expected_user3_pin_2_pos = (40 + 56) % 52;
-    assert_eq!(user3_pin_2_pos, expected_user3_pin_2_pos);
+    assert_position_2_eq(@user3, expected_user3_pin_2_pos);
 
     let player_session = context.marquis_game_dispatcher.player_session(player_0);
     println!("-- Player 0 session: {:?}", player_session);
@@ -1190,19 +1082,15 @@ fn test_player0_wins() {
     let ludo_move_3 = LudoMove { token_id: 3 };
 
     println!("-- Playing move for player 0 pin 3 to win");
-    let (session_data, ludo_session_status) = player_move(context, @ludo_move_3, player_0, var_rand_num_array12);
-    println!("{:?}", session_data);
-    println!("{:?}", ludo_session_status);
+    let (user0, _, _, _) = player_move(context, @ludo_move_3, player_0, var_rand_num_array12);
+    let expected_user0_pin_3_pos = 1 + 56;
+    assert_position_3_eq(@user0, expected_user0_pin_3_pos);
 
+    let (session_data, _) = context.ludo_dispatcher.get_session_status(context.session_id);
     let expected_status = 3; // finished
     let expected_player_count = 0;
     assert_eq!(session_data.status, expected_status);
     assert_eq!(session_data.player_count, expected_player_count);
-
-    let (user0, _, _, _) = ludo_session_status.users;
-    let (_, _, _, user0_pin_3_pos) = user0.player_tokens_position;
-    let expected_user0_pin_3_pos = 1 + 56;
-    assert_eq!(user0_pin_3_pos, expected_user0_pin_3_pos);
 
     let (_, _, _, user0_pin_3_winning) = user0.player_winning_tokens;
     assert!(user0_pin_3_winning);
@@ -1276,108 +1164,68 @@ fn test_player0_wins_with_eth_token() {
     let ludo_move = LudoMove { token_id: 0 };
 
     println!("-- Playing move for player 0");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
+    let (user0, _, _, _) = player_move(context, @ludo_move, player_0, ver_rand_num_array);
     let expected_user0_pin_0_pos = 1 + 56;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user0_pin_0_pos, expected_user0_pin_0_pos);
+    assert_position_0_eq(@user0, expected_user0_pin_0_pos);
 
     println!("-- Playing move for player 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (user0_pin_0_pos, _, _, _) = user0.player_tokens_position;
-    let (user1_pin_0_pos, _, _, _) = user1.player_tokens_position;
-    let expected_use1_pin_0_pos = (14 + 56) % 52;
-    println!("-- User 0 pin 0 pos: {:?}", user0_pin_0_pos);
-    println!("-- User 1 pin 0 pos: {:?}", user1_pin_0_pos);
-    assert_eq!(user1_pin_0_pos, expected_use1_pin_0_pos);
+    let (_, user1, _, _) = player_move(context, @ludo_move, player_1, ver_rand_num_array1);
+    let expected_user1_pin_0_pos = (14 + 56) % 52;
+    assert_position_0_eq(@user1, expected_user1_pin_0_pos);
 
     println!("-- Playing move for player 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
-    let (_, _, user2, _) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user2.player_tokens_position;
+    let (_, _, user2, _) = player_move(context, @ludo_move, player_2, ver_rand_num_array2);
     let expected_pin_0_pos = (27 + 56) % 52;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user2, expected_pin_0_pos);
 
     println!("-- Playing move for player 3");
-    let (_, ludo_session_status) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
-    let (_, _, _, user3) = ludo_session_status.users;
-    let (pin_0_pos, _, _, _) = user3.player_tokens_position;
+    let (_, _, _, user3) = player_move(context, @ludo_move, player_3, ver_rand_num_array3);
     let expected_pin_0_pos = (40 + 56) % 52;
-    assert_eq!(pin_0_pos, expected_pin_0_pos);
+    assert_position_0_eq(@user3, expected_pin_0_pos);
 
     let ludo_move_1 = LudoMove { token_id: 1 };
 
     println!("-- Playing move for player 0 pin 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_1, player_0, var_rand_num_array4);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (_, user0_pin_1_pos, _, _) = user0.player_tokens_position;
-    let (_, user1_pin_1_pos, _, _) = user1.player_tokens_position;
-    println!("-- User 0 pin 1 pos: {:?}", user0_pin_1_pos);
-    println!("-- User 1 pin 1 pos: {:?}", user1_pin_1_pos);
+    let (user0, _, _, _) = player_move(context, @ludo_move_1, player_0, var_rand_num_array4);
     let expected_user0_pin_1_pos = 1 + 56;
-    assert_eq!(user0_pin_1_pos, expected_user0_pin_1_pos);
-    assert_eq!(user1_pin_1_pos, 0);
+    assert_position_1_eq(@user0, expected_user0_pin_1_pos);
 
     println!("-- Playing move for player 1 pin 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_1, player_1, var_rand_num_array5);
-    let (_, user1, _, _) = ludo_session_status.users;
-    let (_, user1_pin_1_pos, _, _) = user1.player_tokens_position;
+    let (_, user1, _, _) = player_move(context, @ludo_move_1, player_1, var_rand_num_array5);
     let expected_user1_pin_1_pos = (14 + 56) % 52;
-    assert_eq!(user1_pin_1_pos, expected_user1_pin_1_pos);
+    assert_position_1_eq(@user1, expected_user1_pin_1_pos);
 
     println!("-- Playing move for player 2 pin 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_1, player_2, var_rand_num_array6);
-    let (_, _, user2, _) = ludo_session_status.users;
-    let (_, user2_pin_1_pos, _, _) = user2.player_tokens_position;
+    let (_, _, user2, _) = player_move(context, @ludo_move_1, player_2, var_rand_num_array6);
     let expected_user2_pin_1_pos = (27 + 56) % 52;
-    assert_eq!(user2_pin_1_pos, expected_user2_pin_1_pos);
+    assert_position_1_eq(@user2, expected_user2_pin_1_pos);
 
     println!("-- Playing move for player 3 pin 1");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_1, player_3, var_rand_num_array7);
-    let (_, _, _, user3) = ludo_session_status.users;
-    let (_, user3_pin_1_pos, _, _) = user3.player_tokens_position;
+    let (_, _, _, user3) = player_move(context, @ludo_move_1, player_3, var_rand_num_array7);
     let expected_user3_pin_1_pos = (40 + 56) % 52;
-    assert_eq!(user3_pin_1_pos, expected_user3_pin_1_pos);
+    assert_position_1_eq(@user3, expected_user3_pin_1_pos);
 
     let ludo_move_2 = LudoMove { token_id: 2 };
 
     println!("-- Playing move for player 0 pin 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_2, player_0, var_rand_num_array8);
-    let (user0, user1, _, _) = ludo_session_status.users;
-    let (_, _, user0_pin_2_pos, _) = user0.player_tokens_position;
-    let (_, _, user1_pin_2_pos, _) = user1.player_tokens_position;
-    println!("-- User 0 pin 2 pos: {:?}", user0_pin_2_pos);
-    println!("-- User 1 pin 2 pos: {:?}", user1_pin_2_pos);
+    let (user0, _, _, _) = player_move(context, @ludo_move_2, player_0, var_rand_num_array8);
     let expected_user0_pin_2_pos = 1 + 56;
-    assert_eq!(user0_pin_2_pos, expected_user0_pin_2_pos);
-    assert_eq!(user1_pin_2_pos, 0);
+    assert_position_2_eq(@user0, expected_user0_pin_2_pos);
 
     println!("-- Playing move for player 1 pin 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_2, player_1, var_rand_num_array9);
-    let (_, user1, _, _) = ludo_session_status.users;
-    let (_, _, user1_pin_2_pos, _) = user1.player_tokens_position;
+    let (_, user1, _, _) = player_move(context, @ludo_move_2, player_1, var_rand_num_array9);
     let expected_user1_pin_2_pos = (14 + 56) % 52;
-    assert_eq!(user1_pin_2_pos, expected_user1_pin_2_pos);
+    assert_position_2_eq(@user1, expected_user1_pin_2_pos);
 
     println!("-- Playing move for player 2 pin 2");
-    let (_, ludo_session_status) = player_move(context, @ludo_move_2, player_2, var_rand_num_array10);
-    let (_, _, user2, _) = ludo_session_status.users;
-    let (_, _, user2_pin_2_pos, _) = user2.player_tokens_position;
+    let (_, _, user2, _) = player_move(context, @ludo_move_2, player_2, var_rand_num_array10);
     let expected_user2_pin_2_pos = (27 + 56) % 52;
-    assert_eq!(user2_pin_2_pos, expected_user2_pin_2_pos);
+    assert_position_2_eq(@user2, expected_user2_pin_2_pos);
 
     println!("-- Playing move for player 3 pin 2");
-    let (session_data, ludo_session_status) = player_move(context, @ludo_move_2, player_3, var_rand_num_array11);
-    println!("{:?}", session_data);
-    println!("{:?}", ludo_session_status);
-    let (_, _, _, user3) = ludo_session_status.users;
-    let (_, _, user3_pin_2_pos, _) = user3.player_tokens_position;
+    let (_, _, _, user3) = player_move(context, @ludo_move_2, player_3, var_rand_num_array11);
     let expected_user3_pin_2_pos = (40 + 56) % 52;
-    assert_eq!(user3_pin_2_pos, expected_user3_pin_2_pos);
+    assert_position_2_eq(@user3, expected_user3_pin_2_pos);
 
     let player_session = context.marquis_game_dispatcher.player_session(player_0);
     println!("-- Player 0 session: {:?}", player_session);
@@ -1387,8 +1235,11 @@ fn test_player0_wins_with_eth_token() {
     println!("-- Playing move for player 0 pin 3 to win");
     let ludo_move_3 = LudoMove { token_id: 3 };
     let mut spy = spy_events();
-    cheat_caller_address(context.ludo_contract, player_0, CheatSpan::TargetCalls(1));
-    context.ludo_dispatcher.play(context.session_id, ludo_move_3, var_rand_num_array12);
+
+    let (user0, _, _, _) = player_move(context, @ludo_move_3, player_0, var_rand_num_array12);
+    let expected_user0_pin_3_pos = 1 + 56;
+    assert_position_3_eq(@user0, expected_user0_pin_3_pos);
+    
     let events_from_ludo_contract = spy.get_events().emitted_by(context.ludo_contract);
     let (from, event_from_ludo) = events_from_ludo_contract.events.at(0);
 
@@ -1409,11 +1260,6 @@ fn test_player0_wins_with_eth_token() {
     let expected_player_count = 0;
     assert_eq!(session_data.status, expected_status);
     assert_eq!(session_data.player_count, expected_player_count);
-
-    let (user0, _, _, _) = ludo_session_status.users;
-    let (_, _, _, user0_pin_3_pos) = user0.player_tokens_position;
-    let expected_user0_pin_3_pos = 1 + 56;
-    assert_eq!(user0_pin_3_pos, expected_user0_pin_3_pos);
 
     let (_, _, _, user0_pin_3_winning) = user0.player_winning_tokens;
     assert!(user0_pin_3_winning);

--- a/packages/snfoundry/contracts/src/test/TestContract.cairo
+++ b/packages/snfoundry/contracts/src/test/TestContract.cairo
@@ -105,6 +105,8 @@ fn start_game(
         player_0_init_balance = erc20_dispatcher.balance_of(player_0);
         cheat_caller_address(token, player_0, CheatSpan::TargetCalls(1));
         erc20_dispatcher.approve(ludo_contract, amount);
+
+        println!("-- Player 0 balance before joining: {:?}", player_0_init_balance);
     }
 
     cheat_caller_address(ludo_contract, player_0, CheatSpan::TargetCalls(1));
@@ -141,6 +143,10 @@ fn setup_game_4_players(
         erc20_dispatcher.approve(ludo_contract, amount);
         cheat_caller_address(token, player_3, CheatSpan::TargetCalls(1));
         erc20_dispatcher.approve(ludo_contract, amount);
+
+        println!("-- Player 1 balance before joining: {:?}", player_1_init_balance);
+        println!("-- Player 2 balance before joining: {:?}", player_2_init_balance);
+        println!("-- Player 3 balance before joining: {:?}", player_3_init_balance);
     }
 
     cheat_caller_address(ludo_contract, player_1, CheatSpan::TargetCalls(1));
@@ -322,7 +328,10 @@ fn test_join_session_with_eth_token() {
     // given
     let eth_contract_address = ETH_TOKEN_ADDRESS();
     let amount = 100;
-    let (ludo_contract, ludo_dispatcher, marquis_game_dispatcher, session_id, player_0_init_balance) = start_game(
+    let (
+        ludo_contract, ludo_dispatcher, marquis_game_dispatcher, session_id, player_0_init_balance,
+    ) =
+        start_game(
         eth_contract_address, amount,
     );
 
@@ -346,8 +355,10 @@ fn test_join_session_with_eth_token() {
     assert_eq!(status, expected_status);
 
     let player_0_balance_after_join = erc20_dispatcher.balance_of(player_0);
+    println!("-- Player 0 balance after joining: {:?}", player_0_balance_after_join);
     assert_eq!(player_0_balance_after_join, player_0_init_balance - amount);
     let player_1_balance_after_join = erc20_dispatcher.balance_of(player_1);
+    println!("-- Player 1 balance after joining: {:?}", player_1_balance_after_join);
     assert_eq!(player_1_balance_after_join, player_1_init_balance - amount);
 }
 

--- a/packages/snfoundry/contracts/src/test/TestContract.cairo
+++ b/packages/snfoundry/contracts/src/test/TestContract.cairo
@@ -211,11 +211,11 @@ fn assert_position_3_eq(user:@SessionUserStatus, expected_pos: u256) {
 // MARQUIS CONTRACT TESTS
 
 #[test]
-fn test_deploy_marquis_contract() {
+fn should_deploy_marquis_contract() {
     deploy_marquis_contract();
 }
 #[test]
-fn test_add_supported_token() {
+fn should_add_supported_token_successfully() {
     let marquis_contract = deploy_marquis_contract();
     let marquis_dispatcher = IMarquisCoreDispatcher { contract_address: marquis_contract };
     let token_address = USDC_TOKEN_ADDRESS();
@@ -226,7 +226,7 @@ fn test_add_supported_token() {
 }
 
 #[test]
-fn test_update_supported_token_fee() {
+fn should_update_token_fee_when_owner() {
     let marquis_contract = deploy_marquis_contract();
     let marquis_dispatcher = IMarquisCoreDispatcher { contract_address: marquis_contract };
     let new_fee = 10;
@@ -239,7 +239,7 @@ fn test_update_supported_token_fee() {
 }
 
 #[test]
-fn test_withdraw_from_marquis_code() {
+fn should_withdraw_specified_amount_from_contract() {
     let marquis_contract = deploy_marquis_contract();
     let strk_token_address = deploy_erc20_contract("STRK", STRK_TOKEN_ADDRESS());
     let owner = OWNER();
@@ -265,7 +265,7 @@ fn test_withdraw_from_marquis_code() {
 }
 
 #[test]
-fn test_withdraw_all_from_marquis_code() {
+fn should_withdraw_all_funds_from_contract() {
     let marquis_contract = deploy_marquis_contract();
     let strk_token_address = deploy_erc20_contract("STRK", STRK_TOKEN_ADDRESS());
     let owner = OWNER();
@@ -290,7 +290,7 @@ fn test_withdraw_all_from_marquis_code() {
 }
 
 #[test]
-fn get_all_supported_token() {
+fn should_return_all_supported_tokens() {
     let marquis_contract = deploy_marquis_contract();
     let marquis_dispatcher = IMarquisCoreDispatcher { contract_address: marquis_contract };
     let token_address = STRK_TOKEN_ADDRESS();
@@ -305,11 +305,11 @@ fn get_all_supported_token() {
 // LUDO CONTRACT TESTS
 
 #[test]
-fn test_deploy_contracts() {
+fn should_deploy_ludo_contract() {
     deploy_ludo_contract();
 }
 #[test]
-fn test_game_name() {
+fn should_return_correct_game_name() {
     let ludo_contract = deploy_ludo_contract();
     let marquis_game_dispatcher = IMarquisGameDispatcher { contract_address: ludo_contract };
     let expected_name = "Ludo";
@@ -318,7 +318,7 @@ fn test_game_name() {
 }
 
 #[test]
-fn test_create_session() {
+fn should_create_new_game_session() {
     let ludo_contract = deploy_ludo_contract();
     let marquis_game_dispatcher = IMarquisGameDispatcher { contract_address: ludo_contract };
     let token = ZERO_TOKEN();
@@ -329,7 +329,7 @@ fn test_create_session() {
 }
 
 #[test]
-fn test_create_session_with_eth_token() {
+fn should_create_new_game_session_with_eth_token_deposit() {
 
     // given
     let eth_contract_address = ETH_TOKEN_ADDRESS();
@@ -351,7 +351,7 @@ fn test_create_session_with_eth_token() {
 }
 
 #[test]
-fn test_join_session() {
+fn should_allow_player_to_join_session() {
     // given
     let (context, _) = setup_game_new(
         ZERO_TOKEN(), 0,
@@ -373,7 +373,7 @@ fn test_join_session() {
 }
 
 #[test]
-fn test_join_session_with_eth_token() {
+fn should_allow_player_to_join_with_eth_token_stake() {
     // given
     let eth_contract_address = ETH_TOKEN_ADDRESS();
     let amount = 100;
@@ -412,7 +412,7 @@ fn test_join_session_with_eth_token() {
 }
 
 #[test]
-fn test_needs_4_players_to_play() {
+fn should_require_four_players_to_start_game() {
     // given
     let (context, _) = setup_game_new(
         ZERO_TOKEN(), 0,
@@ -454,7 +454,7 @@ fn test_needs_4_players_to_play() {
 }
 
 #[test]
-fn test_one_player_finish_session_before_game_starts_with_two_players() {
+fn should_allow_player_to_finish_before_game_starts() {
     let (context, _) = setup_game_new(
         ZERO_TOKEN(), 0,
     );
@@ -489,7 +489,7 @@ fn test_one_player_finish_session_before_game_starts_with_two_players() {
 }
 
 #[test]
-fn test_player_finish_session_before_game_starts_with_two_players() {
+fn should_allow_players_to_finish_incomplete_game() {
     let (context, _) = setup_game_new(
         ZERO_TOKEN(), 0,
     );
@@ -530,7 +530,7 @@ fn test_player_finish_session_before_game_starts_with_two_players() {
 }
 
 #[test]
-fn test_owner_finish_session_ongoing_game() {
+fn should_allow_owner_to_force_finish_game() {
     let (context, _) =
         setup_game_4_players(
         ZERO_TOKEN(), 0,
@@ -546,7 +546,7 @@ fn test_owner_finish_session_ongoing_game() {
     assert_eq!(status, expected_status);
 }
 #[test]
-fn test_player_finish_session_ongoing_game() {
+fn should_allow_player_to_finish_ongoing_game() {
     let player_0 = PLAYER_0();
     let player_1 = PLAYER_1();
 
@@ -576,7 +576,7 @@ fn test_player_finish_session_ongoing_game() {
 }
 
 #[test]
-fn test_owner_finish_session_with_eth_token_ongoing_game() {
+fn should_refund_eth_when_owner_finishes_game() {
     // given
     let eth_contract_address = ETH_TOKEN_ADDRESS();
     let amount = 10000;
@@ -608,7 +608,7 @@ fn test_owner_finish_session_with_eth_token_ongoing_game() {
 }
 
 #[test]
-fn test_player_finish_session_with_eth_token_ongoing_game() {
+fn should_distribute_eth_when_player_finishes_game() {
     // given
     let eth_contract_address = ETH_TOKEN_ADDRESS();
     let amount = 30000;
@@ -646,7 +646,7 @@ fn test_player_finish_session_with_eth_token_ongoing_game() {
     assert_eq!(player_3_balance_after, player_3_expected_balance);
 }
 #[test]
-fn test_get_6_and_play() {
+fn should_allow_move_when_rolling_six() {
     let player_0 = PLAYER_0();
 
     let (context, _) = setup_game_4_players(ZERO_TOKEN(), 0);
@@ -660,7 +660,7 @@ fn test_get_6_and_play() {
     assert_position_0_eq(@user0, expected_pin_0_pos);
 }
 #[test]
-fn test_player_0_doesnt_get_6_and_player_1_does_get_6() {
+fn should_skip_turn_when_not_rolling_six() {
     let player_0 = PLAYER_0();
     let player_1 = PLAYER_1();
 
@@ -685,7 +685,7 @@ fn test_player_0_doesnt_get_6_and_player_1_does_get_6() {
 }
 #[test]
 // Player 0 kills player 1 pin0
-fn test_kill() {
+fn should_kill_opponent_token_on_same_position() {
     let player_0 = PLAYER_0();
     let player_1 = PLAYER_1();
     let player_2 = PLAYER_2();
@@ -733,7 +733,7 @@ fn test_kill() {
     assert_position_0_eq(@user1, 0);
 }
 #[test]
-fn test_user0_pin0_wins() {
+fn should_win_when_player_reaches_home() {
     let player_0 = PLAYER_0();
     let player_1 = PLAYER_1();
     let player_2 = PLAYER_2();
@@ -804,7 +804,7 @@ fn test_user0_pin0_wins() {
 
 #[test]
 // Player 0 kills player 1 circled pin0
-fn test_attack_circled() {
+fn tshould_kill_opponent_token_after_full_circle() {
     let player_0 = PLAYER_0();
     let player_1 = PLAYER_1();
     let player_2 = PLAYER_2();
@@ -881,7 +881,7 @@ fn test_attack_circled() {
 }
 
 #[test]
-fn test_user0_user1_user2_user3_wins() {
+fn should_allow_all_player_to_reach_home() {
     let player_0 = PLAYER_0();
     let player_1 = PLAYER_1();
     let player_2 = PLAYER_2();
@@ -952,7 +952,7 @@ fn test_user0_user1_user2_user3_wins() {
 }
 
 #[test]
-fn test_player0_wins() {
+fn should_end_game_when_player_wins_with_all_tokens() {
     let player_0 = PLAYER_0();
     let player_1 = PLAYER_1();
     let player_2 = PLAYER_2();
@@ -1101,7 +1101,7 @@ fn test_player0_wins() {
 }
 
 #[test]
-fn test_player0_wins_with_eth_token() {
+fn should_distribute_eth_prize_to_winner() {
     // given
     let eth_contract_address = ETH_TOKEN_ADDRESS();
     let amount = 100;

--- a/packages/snfoundry/contracts/src/test/TestContract.cairo
+++ b/packages/snfoundry/contracts/src/test/TestContract.cairo
@@ -97,7 +97,7 @@ struct GameContext {
     session_id: u256,
 }
 
-fn start_game(
+fn setup_game_new(
     token: ContractAddress, amount: u256,
 ) -> (GameContext, u256) {
     let ludo_contract = deploy_ludo_contract();
@@ -131,7 +131,7 @@ fn setup_game_4_players(
     let (
         context, player_0_init_balance,
     ) =
-        start_game(
+        setup_game_new(
         token, amount,
     );
 
@@ -337,7 +337,7 @@ fn test_create_session_with_eth_token() {
     let (
         context, player_0_init_balance,
     ) =
-        start_game(
+        setup_game_new(
         eth_contract_address, amount,
     );
 
@@ -353,7 +353,7 @@ fn test_create_session_with_eth_token() {
 #[test]
 fn test_join_session() {
     // given
-    let (context, _) = start_game(
+    let (context, _) = setup_game_new(
         ZERO_TOKEN(), 0,
     );
 
@@ -380,7 +380,7 @@ fn test_join_session_with_eth_token() {
     let (
         context, player_0_init_balance,
     ) =
-        start_game(
+        setup_game_new(
         eth_contract_address, amount,
     );
 
@@ -414,7 +414,7 @@ fn test_join_session_with_eth_token() {
 #[test]
 fn test_needs_4_players_to_play() {
     // given
-    let (context, _) = start_game(
+    let (context, _) = setup_game_new(
         ZERO_TOKEN(), 0,
     );
 
@@ -455,7 +455,7 @@ fn test_needs_4_players_to_play() {
 
 #[test]
 fn test_one_player_finish_session_before_game_starts_with_two_players() {
-    let (context, _) = start_game(
+    let (context, _) = setup_game_new(
         ZERO_TOKEN(), 0,
     );
     let player_0 = PLAYER_0();
@@ -490,7 +490,7 @@ fn test_one_player_finish_session_before_game_starts_with_two_players() {
 
 #[test]
 fn test_player_finish_session_before_game_starts_with_two_players() {
-    let (context, _) = start_game(
+    let (context, _) = setup_game_new(
         ZERO_TOKEN(), 0,
     );
     let player_0 = PLAYER_0();

--- a/packages/snfoundry/contracts/src/test/mock/ERC20.cairo
+++ b/packages/snfoundry/contracts/src/test/mock/ERC20.cairo
@@ -1,0 +1,38 @@
+#[starknet::contract]
+mod ERC20 {
+    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
+    use starknet::ContractAddress;
+
+    component!(path: ERC20Component, storage: erc20, event: ERC20Event);
+
+    // ERC20 Mixin
+    #[abi(embed_v0)]
+    impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
+    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        #[substorage(v0)]
+        erc20: ERC20Component::Storage
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        ERC20Event: ERC20Component::Event
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        symbol: ByteArray,
+        initial_supply: u256,
+        recipient: ContractAddress
+    ) {
+        let name = "MyToken";
+
+        self.erc20.initializer(name, symbol);
+        self.erc20.mint(recipient, initial_supply);
+    }
+}

--- a/packages/snfoundry/contracts/src/test/mock/ERC20.cairo
+++ b/packages/snfoundry/contracts/src/test/mock/ERC20.cairo
@@ -13,14 +13,14 @@ mod ERC20 {
     #[storage]
     struct Storage {
         #[substorage(v0)]
-        erc20: ERC20Component::Storage
+        erc20: ERC20Component::Storage,
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
         #[flat]
-        ERC20Event: ERC20Component::Event
+        ERC20Event: ERC20Component::Event,
     }
 
     #[constructor]
@@ -28,7 +28,7 @@ mod ERC20 {
         ref self: ContractState,
         symbol: ByteArray,
         initial_supply: u256,
-        recipient: ContractAddress
+        recipient: ContractAddress,
     ) {
         let name = "MyToken";
 


### PR DESCRIPTION
# use ERC20 mocks instead forking sepolia

Fixes #33
Its an alternative fix for #104
Forking sepolia in test is not real revelant and cause issue with RPC rate limiter, so I propose to remove forking in tests

## Types of change

- [x] add simple ERC20 implementation into test package
- [x] create a new function to deploy an ERC20 during test
    - [x] still use sepolia address for ETH and STRK
- [x] use this mock contract over all fork tests

## Comments (optional)

- The best solution I think 
- This branch is based on `test-develop` to start with working tests

## UPDATE (18/12)

I have refactored tests for more readability and reliability. I try to keep in mind the accessibility of the code and the ease of adding new tests.

- [x] Introduced new utility functions:  
    - [x] Set up a new game with `setup_game_new()` and `setup_game_4_players()`  
    - [x] Perform a move with `player_move()`  
    - [x] Test user positions with `assert_position_X_eq()`  
- [x] Isolated status checks in specific tests; no need to check them in all tests.  
- [x] Globally reduced the number of repeated useless assertions.  
- [x] Tried to isolate `println` statements.  
- [x] Reduced the number of lines in test file by 22%.

Things I didn’t touch:  
- [ ] I don't try to fix the logic, I keep all tests as they are  
    - [ ] but I think the tests that reproduce the same behavior with or without ETH, like `test_player0_wins`, can be removed.  
    - [ ] And globally, I renamed nothing.  
- [ ] Utility functions could be move to dedicated file
- [ ] Maybe the next step is to simplify the definition of moves, or at least find another solution to `clone()`.