### PR TITLE
Ludo Game Contracts: Improve function signatures #140

### DIFF
--- a/packages/snfoundry/contracts/src/interfaces/IMarquisGame.cairo
+++ b/packages/snfoundry/contracts/src/interfaces/IMarquisGame.cairo
@@ -118,7 +118,10 @@ pub trait IMarquisGame<ContractState> {
     /// @param required_players The required players for the session
     /// @return The ID of the newly created session
     fn create_session(
-        ref self: ContractState, token: ContractAddress, amount: u256, required_players: u32,
+        ref self: ContractState,
+        option_token: Option<ContractAddress>,
+        option_amount: Option<u256>,
+        required_players: u32,
     ) -> u256;
 
     /// @notice Joins an existing game session

--- a/packages/snfoundry/contracts/src/tests/Base.cairo
+++ b/packages/snfoundry/contracts/src/tests/Base.cairo
@@ -145,7 +145,8 @@ fn should_panic_when_game_is_initialized_with_unsupported_token() {
     let required_players = 2;
 
     cheat_caller_address(ludo_contract, player_0, CheatSpan::TargetCalls(1));
-    let _ = marquis_game_dispatcher.create_session(token_address, amount, required_players);
+    let _ = marquis_game_dispatcher
+        .create_session(Option::Some(token_address), Option::Some(amount), required_players);
 }
 
 #[test]


### PR DESCRIPTION
# Refactored `create_session` to Handle Paid and Free Sessions

Closes #140

## Types of Change

- [ ] Feature
- [x] Bug
- [x] Enhancement

## Description

This PR refactors the `create_session` function to handle both **paid** and **free** sessions using `Option<T>`. The changes include:

1. **Refactored `create_session`**:
   - Updated the function signature to accept `Option<ContractAddress>` for `token` and `Option<u256>` for `amount`.
   - Used `match` patterns to handle `Some` and `None` cases for `token` and `amount`.

2. **Session Management**:
   - Updated the `Session` struct to support optional `play_token` and `play_amount`.
   - Added logic to handle both paid and free sessions.

3. **Fixes for Type Mismatches**:
   - Fixed type mismatches in related functions like `_finish_session` and `_is_token_supported`.
   - Ensured proper unwrapping of `Option<T>` values before performing operations.

4. **Testing**:
   - Updated tests to align with the new `Option<T>` handling.
   - Added test cases for both paid and free sessions.

5. **Code Improvements**:
   - Identified and refactored other sections of the code where `Option<T>` can improve flexibility and robustness.

### Changes Made

1. **Refactored `create_session`**

2. Updated Session Struct

3. Fixed Type Mismatches:

4. Updated _finish_session and _is_token_supported to handle Option<T>.

5. Updates test files.
 

Testing

- Verified that the create_session function works correctly for both paid and free sessions.

- Confirmed that the _finish_session function handles payouts and unlocks players as expected.

- Ran all tests and ensured they pass.

ScreenShot

![Screenshot from 2025-01-26 21-15-37](https://github.com/user-attachments/assets/3c9bc364-6884-4383-a90d-2d2453e4f6c6)


Comments (Optional)

This PR ensures that the contract can handle both paid and free sessions seamlessly.

The use of Option<T> makes the code more flexible and robust.

All type mismatches have been resolved, and the contract now adheres to the expected types.